### PR TITLE
Update solidity version

### DIFF
--- a/casino-dapp/truffle/contracts/flipcontract.sol
+++ b/casino-dapp/truffle/contracts/flipcontract.sol
@@ -1,7 +1,7 @@
 import "../node_modules/@openzeppelin/contracts/access/Ownable.sol";
 import "../node_modules/@openzeppelin/contracts/math/SafeMath.sol";
 
-pragma solidity ^0.7.5;
+pragma solidity ^0.8.9;
 
 contract FlipContract is Ownable {
     


### PR DESCRIPTION
Error: Truffle is currently using solc 0.8.9, but one or more of your contracts specify "pragma solidity ^0.7.5".